### PR TITLE
Update "google/analytics-data", dev dependencies, and support Laravel 13

### DIFF
--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.1'
+          php-version: '8.3'
           coverage: none
 
       - name: Install composer dependencies

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,19 +13,16 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest, windows-latest]
-        php: [8.1, 8.2]
-        laravel: [10.*, 11.*]
+        php: [8.3, 8.4]
+        laravel: [11.*, 12.*, 13.*]
         stability: [prefer-lowest, prefer-stable]
         include:
-          - laravel: 10.*
-            testbench: 8.*
-            carbon: ^2.67
           - laravel: 11.*
             testbench: 9.*
-            carbon: ^2.72.6
-        exclude:
-          - laravel: 11.*
-            php: 8.1
+          - laravel: 12.*
+            testbench: 10.*
+          - laravel: 13.*
+            testbench: 11.*
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 
@@ -47,7 +44,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" "nesbot/carbon:${{ matrix.carbon }}" --no-interaction --no-update
+          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
           composer update --${{ matrix.stability }} --prefer-dist --no-interaction
 
       - name: Execute tests

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -48,4 +48,4 @@ jobs:
           composer update --${{ matrix.stability }} --prefer-dist --no-interaction
 
       - name: Execute tests
-        run: vendor/bin/pest --ci
+        run: vendor/bin/pest --ci --no-coverage

--- a/composer.json
+++ b/composer.json
@@ -17,22 +17,22 @@
     ],
     "require": {
         "php": "^8.1",
-        "google/analytics-data": "^0.9.4",
-        "illuminate/contracts": "^9.0|^10.0|^11.0|^12.0",
+        "google/analytics-data": "^0.23.3",
+        "illuminate/contracts": "^9.0|^10.0|^11.0|^12.0|^13.0",
         "spatie/laravel-package-tools": "^1.14.0"
     },
     "require-dev": {
+        "larastan/larastan": "^3.0",
         "laravel/pint": "^1.0",
         "nunomaduro/collision": "^6.1|^7.0|^8.0",
-        "nunomaduro/larastan": "^2.0.1",
         "orchestra/testbench": "^8.0|^9.0",
         "pestphp/pest": "^1.21|^2.34",
         "pestphp/pest-plugin-laravel": "^1.1|^2.3",
         "phpstan/extension-installer": "^1.1",
-        "phpstan/phpstan-deprecation-rules": "^1.0",
-        "phpstan/phpstan-phpunit": "^1.0",
+        "phpstan/phpstan-deprecation-rules": "^2.0",
+        "phpstan/phpstan-phpunit": "^2.0",
         "phpunit/phpunit": "^9.6|^10.0",
-        "rector/rector": "^0.19.2|^1.0"
+        "rector/rector": "^2.4"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -24,14 +24,14 @@
     "require-dev": {
         "larastan/larastan": "^3.0",
         "laravel/pint": "^1.0",
-        "nunomaduro/collision": "^6.1|^7.0|^8.0",
-        "orchestra/testbench": "^8.0|^9.0",
-        "pestphp/pest": "^1.21|^2.34",
-        "pestphp/pest-plugin-laravel": "^1.1|^2.3",
+        "nunomaduro/collision": "^7.0|^8.0|^9.0",
+        "orchestra/testbench": "^9.0|^10.0|^11.0",
+        "pestphp/pest": "^2.34|^3.0|^4.0",
+        "pestphp/pest-plugin-laravel": "^2.3|^3.0|^4.0",
         "phpstan/extension-installer": "^1.1",
         "phpstan/phpstan-deprecation-rules": "^2.0",
         "phpstan/phpstan-phpunit": "^2.0",
-        "phpunit/phpunit": "^9.6|^10.0",
+        "phpunit/phpunit": "^10.0|^11.0|^12.0",
         "rector/rector": "^2.4"
     },
     "autoload": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,32 +1,30 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
-    backupGlobals="false"
-    backupStaticAttributes="false"
-    bootstrap="vendor/autoload.php"
-    colors="true"
-    convertErrorsToExceptions="true"
-    convertNoticesToExceptions="true"
-    convertWarningsToExceptions="true"
-    processIsolation="false"
-    stopOnFailure="false"
-    executionOrder="random"
-    failOnWarning="true"
-    failOnRisky="true"
-    failOnEmptyTestSuite="true"
-    beStrictAboutOutputDuringTests="true"
-    verbose="true"
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         backupGlobals="false"
+         backupStaticProperties="false"
+         bootstrap="vendor/autoload.php"
+         colors="true"
+         processIsolation="false"
+         stopOnFailure="false"
+         executionOrder="random"
+         failOnWarning="true"
+         failOnRisky="true"
+         failOnEmptyTestSuite="true"
+         beStrictAboutOutputDuringTests="true"
+         cacheDirectory=".phpunit.cache"
 >
     <testsuites>
         <testsuite name="Backstage Test Suite">
             <directory>tests</directory>
         </testsuite>
     </testsuites>
-    <coverage>
+    <source>
         <include>
             <directory suffix=".php">./src</directory>
         </include>
+    </source>
+    <coverage>
         <report>
             <html outputDirectory="build/coverage"/>
             <text outputFile="build/coverage.txt"/>

--- a/src/Analytics.php
+++ b/src/Analytics.php
@@ -11,7 +11,11 @@ use Backstage\Analytics\Traits\Analytics\SessionsAnalytics;
 use Backstage\Analytics\Traits\Analytics\UsersAnalytics;
 use Backstage\Analytics\Traits\Analytics\ViewsAnalytics;
 use Backstage\Analytics\Traits\ResponseFormatterTrait;
-use Google\Analytics\Data\V1beta\BetaAnalyticsDataClient;
+use Google\Analytics\Data\V1beta\Client\BetaAnalyticsDataClient;
+use Google\Analytics\Data\V1beta\RunRealtimeReportRequest;
+use Google\Analytics\Data\V1beta\RunReportRequest;
+use Google\ApiCore\ApiException;
+use Google\ApiCore\ValidationException;
 
 class Analytics
 {
@@ -61,6 +65,9 @@ class Analytics
         return $this->propertyId;
     }
 
+    /**
+     * @throws ValidationException
+     */
     public function getClient(): BetaAnalyticsDataClient
     {
         return new BetaAnalyticsDataClient([
@@ -68,6 +75,10 @@ class Analytics
         ]);
     }
 
+    /**
+     * @throws ValidationException
+     * @throws ApiException
+     */
     public function getReport(GoogleAnalyticsService $googleAnalytics): AnalyticsResponse
     {
         $client = $this->getClient();
@@ -87,11 +98,15 @@ class Analytics
             'keepEmptyRows' => $googleAnalytics->keepEmptyRows,
         ];
 
-        $response = $client->runReport($parameters);
+        $response = $client->runReport(new RunReportRequest($parameters));
 
         return $this->formatResponse($response);
     }
 
+    /**
+     * @throws ValidationException
+     * @throws ApiException
+     */
     public function getRealtimeReport(GoogleAnalyticsService $googleAnalytics): AnalyticsResponse
     {
         $client = $this->getClient();
@@ -111,7 +126,7 @@ class Analytics
             'keepEmptyRows' => $googleAnalytics->keepEmptyRows,
         ];
 
-        $response = $client->runRealtimeReport($parameters);
+        $response = $client->runRealtimeReport(new RunRealtimeReportRequest($parameters));
 
         return $this->formatResponse($response);
     }

--- a/src/Traits/Analytics/DemographicAnalytics.php
+++ b/src/Traits/Analytics/DemographicAnalytics.php
@@ -4,12 +4,14 @@ namespace Backstage\Analytics\Traits\Analytics;
 
 use Backstage\Analytics\Enums\Direction;
 use Backstage\Analytics\Period;
+use Google\ApiCore\ApiException;
+use Google\ApiCore\ValidationException;
 
 trait DemographicAnalytics
 {
     /**
-     * @throws \Google\ApiCore\ApiException
-     * @throws \Google\ApiCore\ValidationException
+     * @throws ApiException
+     * @throws ValidationException
      */
     public function topUsersByLanguage(Period $period, int $limit = 10): array
     {
@@ -25,8 +27,8 @@ trait DemographicAnalytics
     }
 
     /**
-     * @throws \Google\ApiCore\ApiException
-     * @throws \Google\ApiCore\ValidationException
+     * @throws ApiException
+     * @throws ValidationException
      */
     public function totalUsersByLanguage(Period $period): array
     {
@@ -40,8 +42,8 @@ trait DemographicAnalytics
     }
 
     /**
-     * @throws \Google\ApiCore\ApiException
-     * @throws \Google\ApiCore\ValidationException
+     * @throws ApiException
+     * @throws ValidationException
      */
     public function topUsersByCountry(Period $period, int $limit = 10): array
     {
@@ -57,8 +59,8 @@ trait DemographicAnalytics
     }
 
     /**
-     * @throws \Google\ApiCore\ApiException
-     * @throws \Google\ApiCore\ValidationException
+     * @throws ApiException
+     * @throws ValidationException
      */
     public function totalUsersByCountry(Period $period): array
     {
@@ -72,8 +74,8 @@ trait DemographicAnalytics
     }
 
     /**
-     * @throws \Google\ApiCore\ApiException
-     * @throws \Google\ApiCore\ValidationException
+     * @throws ApiException
+     * @throws ValidationException
      */
     public function topUsersByCity(Period $period, int $limit = 10): array
     {
@@ -89,8 +91,8 @@ trait DemographicAnalytics
     }
 
     /**
-     * @throws \Google\ApiCore\ApiException
-     * @throws \Google\ApiCore\ValidationException
+     * @throws ApiException
+     * @throws ValidationException
      */
     public function totalUsersByCity(Period $period): array
     {
@@ -104,8 +106,8 @@ trait DemographicAnalytics
     }
 
     /**
-     * @throws \Google\ApiCore\ApiException
-     * @throws \Google\ApiCore\ValidationException
+     * @throws ApiException
+     * @throws ValidationException
      */
     public function totalUsersByGender(Period $period): array
     {
@@ -120,8 +122,8 @@ trait DemographicAnalytics
     }
 
     /**
-     * @throws \Google\ApiCore\ApiException
-     * @throws \Google\ApiCore\ValidationException
+     * @throws ApiException
+     * @throws ValidationException
      */
     public function totalUsersByAge(Period $period): array
     {

--- a/src/Traits/Analytics/DevicesAnalytics.php
+++ b/src/Traits/Analytics/DevicesAnalytics.php
@@ -4,12 +4,14 @@ namespace Backstage\Analytics\Traits\Analytics;
 
 use Backstage\Analytics\Enums\Direction;
 use Backstage\Analytics\Period;
+use Google\ApiCore\ApiException;
+use Google\ApiCore\ValidationException;
 
 trait DevicesAnalytics
 {
     /**
-     * @throws \Google\ApiCore\ApiException
-     * @throws \Google\ApiCore\ValidationException
+     * @throws ApiException
+     * @throws ValidationException
      */
     public function topUsersByBrowser(Period $period, int $limit = 10): array
     {
@@ -25,8 +27,8 @@ trait DevicesAnalytics
     }
 
     /**
-     * @throws \Google\ApiCore\ApiException
-     * @throws \Google\ApiCore\ValidationException
+     * @throws ApiException
+     * @throws ValidationException
      */
     public function totalUsersByBrowser(Period $period): array
     {
@@ -40,8 +42,8 @@ trait DevicesAnalytics
     }
 
     /**
-     * @throws \Google\ApiCore\ApiException
-     * @throws \Google\ApiCore\ValidationException
+     * @throws ApiException
+     * @throws ValidationException
      */
     public function topUsersByOperatingSystem(Period $period, int $limit = 10): array
     {
@@ -57,8 +59,8 @@ trait DevicesAnalytics
     }
 
     /**
-     * @throws \Google\ApiCore\ApiException
-     * @throws \Google\ApiCore\ValidationException
+     * @throws ApiException
+     * @throws ValidationException
      */
     public function totalUsersByOperatingSystem(Period $period): array
     {
@@ -72,8 +74,8 @@ trait DevicesAnalytics
     }
 
     /**
-     * @throws \Google\ApiCore\ApiException
-     * @throws \Google\ApiCore\ValidationException
+     * @throws ApiException
+     * @throws ValidationException
      */
     public function topUsersByDeviceCategory(Period $period, int $limit = 10): array
     {
@@ -89,8 +91,8 @@ trait DevicesAnalytics
     }
 
     /**
-     * @throws \Google\ApiCore\ApiException
-     * @throws \Google\ApiCore\ValidationException
+     * @throws ApiException
+     * @throws ValidationException
      */
     public function totalUsersByDeviceCategory(Period $period): array
     {
@@ -104,8 +106,8 @@ trait DevicesAnalytics
     }
 
     /**
-     * @throws \Google\ApiCore\ApiException
-     * @throws \Google\ApiCore\ValidationException
+     * @throws ApiException
+     * @throws ValidationException
      */
     public function topUsersByMobileDeviceBranding(Period $period, int $limit = 10): array
     {
@@ -121,8 +123,8 @@ trait DevicesAnalytics
     }
 
     /**
-     * @throws \Google\ApiCore\ApiException
-     * @throws \Google\ApiCore\ValidationException
+     * @throws ApiException
+     * @throws ValidationException
      */
     public function totalUsersByMobileDeviceBranding(Period $period): array
     {
@@ -136,8 +138,8 @@ trait DevicesAnalytics
     }
 
     /**
-     * @throws \Google\ApiCore\ApiException
-     * @throws \Google\ApiCore\ValidationException
+     * @throws ApiException
+     * @throws ValidationException
      */
     public function topUsersByMobileDeviceModel(Period $period, int $limit = 10): array
     {
@@ -153,8 +155,8 @@ trait DevicesAnalytics
     }
 
     /**
-     * @throws \Google\ApiCore\ApiException
-     * @throws \Google\ApiCore\ValidationException
+     * @throws ApiException
+     * @throws ValidationException
      */
     public function totalUsersByMobileDeviceModel(Period $period): array
     {
@@ -168,8 +170,8 @@ trait DevicesAnalytics
     }
 
     /**
-     * @throws \Google\ApiCore\ApiException
-     * @throws \Google\ApiCore\ValidationException
+     * @throws ApiException
+     * @throws ValidationException
      */
     public function topUsersByMobileInputSelector(Period $period, int $limit = 10): array
     {
@@ -185,8 +187,8 @@ trait DevicesAnalytics
     }
 
     /**
-     * @throws \Google\ApiCore\ApiException
-     * @throws \Google\ApiCore\ValidationException
+     * @throws ApiException
+     * @throws ValidationException
      */
     public function totalUsersByMobileInputSelector(Period $period): array
     {
@@ -200,8 +202,8 @@ trait DevicesAnalytics
     }
 
     /**
-     * @throws \Google\ApiCore\ApiException
-     * @throws \Google\ApiCore\ValidationException
+     * @throws ApiException
+     * @throws ValidationException
      */
     public function topUsersByMobileDeviceInfo(Period $period, int $limit = 10): array
     {
@@ -217,8 +219,8 @@ trait DevicesAnalytics
     }
 
     /**
-     * @throws \Google\ApiCore\ApiException
-     * @throws \Google\ApiCore\ValidationException
+     * @throws ApiException
+     * @throws ValidationException
      */
     public function totalUsersByMobileDeviceInfo(Period $period): array
     {
@@ -232,8 +234,8 @@ trait DevicesAnalytics
     }
 
     /**
-     * @throws \Google\ApiCore\ApiException
-     * @throws \Google\ApiCore\ValidationException
+     * @throws ApiException
+     * @throws ValidationException
      */
     public function topUsersByMobileDeviceMarketingName(Period $period, int $limit = 10): array
     {
@@ -249,8 +251,8 @@ trait DevicesAnalytics
     }
 
     /**
-     * @throws \Google\ApiCore\ApiException
-     * @throws \Google\ApiCore\ValidationException
+     * @throws ApiException
+     * @throws ValidationException
      */
     public function totalUsersByMobileDeviceMarketingName(Period $period): array
     {
@@ -264,8 +266,8 @@ trait DevicesAnalytics
     }
 
     /**
-     * @throws \Google\ApiCore\ApiException
-     * @throws \Google\ApiCore\ValidationException
+     * @throws ApiException
+     * @throws ValidationException
      */
     public function topUsersByScreenResolution(Period $period, int $limit = 10): array
     {
@@ -281,8 +283,8 @@ trait DevicesAnalytics
     }
 
     /**
-     * @throws \Google\ApiCore\ApiException
-     * @throws \Google\ApiCore\ValidationException
+     * @throws ApiException
+     * @throws ValidationException
      */
     public function totalUsersByScreenResolution(Period $period): array
     {
@@ -296,8 +298,8 @@ trait DevicesAnalytics
     }
 
     /**
-     * @throws \Google\ApiCore\ApiException
-     * @throws \Google\ApiCore\ValidationException
+     * @throws ApiException
+     * @throws ValidationException
      */
     public function topUsersByPlatform(Period $period, int $limit = 10): array
     {
@@ -313,8 +315,8 @@ trait DevicesAnalytics
     }
 
     /**
-     * @throws \Google\ApiCore\ApiException
-     * @throws \Google\ApiCore\ValidationException
+     * @throws ApiException
+     * @throws ValidationException
      */
     public function totalUsersByPlatform(Period $period): array
     {

--- a/src/Traits/Analytics/RealtimeAnalytics.php
+++ b/src/Traits/Analytics/RealtimeAnalytics.php
@@ -3,13 +3,15 @@
 namespace Backstage\Analytics\Traits\Analytics;
 
 use Backstage\Analytics\Period;
+use Google\ApiCore\ApiException;
+use Google\ApiCore\ValidationException;
 use Illuminate\Support\Arr;
 
 trait RealtimeAnalytics
 {
     /**
-     * @throws \Google\ApiCore\ApiException
-     * @throws \Google\ApiCore\ValidationException
+     * @throws ApiException
+     * @throws ValidationException
      */
     public function activeUsers(?Period $period = null, ?string $path = null): int|array
     {

--- a/src/Traits/Analytics/SessionsAnalytics.php
+++ b/src/Traits/Analytics/SessionsAnalytics.php
@@ -3,13 +3,15 @@
 namespace Backstage\Analytics\Traits\Analytics;
 
 use Backstage\Analytics\Period;
+use Google\ApiCore\ApiException;
+use Google\ApiCore\ValidationException;
 use Illuminate\Support\Arr;
 
 trait SessionsAnalytics
 {
     /**
-     * @throws \Google\ApiCore\ApiException
-     * @throws \Google\ApiCore\ValidationException
+     * @throws ApiException
+     * @throws ValidationException
      */
     public function sessions(Period $period): int
     {
@@ -36,8 +38,8 @@ trait SessionsAnalytics
     }
 
     /**
-     * @throws \Google\ApiCore\ApiException
-     * @throws \Google\ApiCore\ValidationException
+     * @throws ApiException
+     * @throws ValidationException
      */
     public function averageSessionDuration(Period $period): float
     {
@@ -52,8 +54,8 @@ trait SessionsAnalytics
     }
 
     /**
-     * @throws \Google\ApiCore\ApiException
-     * @throws \Google\ApiCore\ValidationException
+     * @throws ApiException
+     * @throws ValidationException
      */
     public function averageSessionDurationByDate(Period $period): array
     {
@@ -69,8 +71,8 @@ trait SessionsAnalytics
     }
 
     /**
-     * @throws \Google\ApiCore\ApiException
-     * @throws \Google\ApiCore\ValidationException
+     * @throws ApiException
+     * @throws ValidationException
      */
     public function averageSessionDurationInSecondsByPage(Period $period): array
     {
@@ -84,8 +86,8 @@ trait SessionsAnalytics
     }
 
     /**
-     * @throws \Google\ApiCore\ApiException
-     * @throws \Google\ApiCore\ValidationException
+     * @throws ApiException
+     * @throws ValidationException
      */
     public function averagePageViewsPerSession(Period $period): float
     {
@@ -100,8 +102,8 @@ trait SessionsAnalytics
     }
 
     /**
-     * @throws \Google\ApiCore\ApiException
-     * @throws \Google\ApiCore\ValidationException
+     * @throws ApiException
+     * @throws ValidationException
      */
     public function averagePageViewsPerSessionByDate(Period $period): array
     {
@@ -117,8 +119,8 @@ trait SessionsAnalytics
     }
 
     /**
-     * @throws \Google\ApiCore\ApiException
-     * @throws \Google\ApiCore\ValidationException
+     * @throws ApiException
+     * @throws ValidationException
      */
     public function averageSessionDurationInSeconds(Period $period): float
     {
@@ -133,8 +135,8 @@ trait SessionsAnalytics
     }
 
     /**
-     * @throws \Google\ApiCore\ApiException
-     * @throws \Google\ApiCore\ValidationException
+     * @throws ApiException
+     * @throws ValidationException
      */
     public function averageSessionDurationInSecondsByDate(Period $period): array
     {
@@ -150,8 +152,8 @@ trait SessionsAnalytics
     }
 
     /**
-     * @throws \Google\ApiCore\ApiException
-     * @throws \Google\ApiCore\ValidationException
+     * @throws ApiException
+     * @throws ValidationException
      */
     public function bounceRate(Period $period): float
     {
@@ -166,8 +168,8 @@ trait SessionsAnalytics
     }
 
     /**
-     * @throws \Google\ApiCore\ApiException
-     * @throws \Google\ApiCore\ValidationException
+     * @throws ApiException
+     * @throws ValidationException
      */
     public function bounceRateByDate(Period $period): array
     {
@@ -183,8 +185,8 @@ trait SessionsAnalytics
     }
 
     /**
-     * @throws \Google\ApiCore\ApiException
-     * @throws \Google\ApiCore\ValidationException
+     * @throws ApiException
+     * @throws ValidationException
      */
     public function bounceRateByPage(Period $period): array
     {

--- a/src/Traits/Analytics/UsersAnalytics.php
+++ b/src/Traits/Analytics/UsersAnalytics.php
@@ -3,13 +3,15 @@
 namespace Backstage\Analytics\Traits\Analytics;
 
 use Backstage\Analytics\Period;
+use Google\ApiCore\ApiException;
+use Google\ApiCore\ValidationException;
 use Illuminate\Support\Arr;
 
 trait UsersAnalytics
 {
     /**
-     * @throws \Google\ApiCore\ApiException
-     * @throws \Google\ApiCore\ValidationException
+     * @throws ApiException
+     * @throws ValidationException
      */
     public function totalUsers(Period $period): int
     {
@@ -24,8 +26,8 @@ trait UsersAnalytics
     }
 
     /**
-     * @throws \Google\ApiCore\ApiException
-     * @throws \Google\ApiCore\ValidationException
+     * @throws ApiException
+     * @throws ValidationException
      */
     public function totalUsersByDate(Period $period): array
     {
@@ -39,8 +41,8 @@ trait UsersAnalytics
     }
 
     /**
-     * @throws \Google\ApiCore\ApiException
-     * @throws \Google\ApiCore\ValidationException
+     * @throws ApiException
+     * @throws ValidationException
      */
     public function totalUsersByDatePerPage(Period $period): array
     {
@@ -55,8 +57,8 @@ trait UsersAnalytics
     }
 
     /**
-     * @throws \Google\ApiCore\ApiException
-     * @throws \Google\ApiCore\ValidationException
+     * @throws ApiException
+     * @throws ValidationException
      */
     public function totalUsersBySessionSource(Period $period): array
     {
@@ -70,8 +72,8 @@ trait UsersAnalytics
     }
 
     /**
-     * @throws \Google\ApiCore\ApiException
-     * @throws \Google\ApiCore\ValidationException
+     * @throws ApiException
+     * @throws ValidationException
      */
     public function totalUsersBySessionMedium(Period $period): array
     {
@@ -85,8 +87,8 @@ trait UsersAnalytics
     }
 
     /**
-     * @throws \Google\ApiCore\ApiException
-     * @throws \Google\ApiCore\ValidationException
+     * @throws ApiException
+     * @throws ValidationException
      */
     public function totalUsersBySessionDevice(Period $period): array
     {

--- a/src/Traits/Analytics/ViewsAnalytics.php
+++ b/src/Traits/Analytics/ViewsAnalytics.php
@@ -4,13 +4,15 @@ namespace Backstage\Analytics\Traits\Analytics;
 
 use Backstage\Analytics\Enums\Direction;
 use Backstage\Analytics\Period;
+use Google\ApiCore\ApiException;
+use Google\ApiCore\ValidationException;
 use Illuminate\Support\Arr;
 
 trait ViewsAnalytics
 {
     /**
-     * @throws \Google\ApiCore\ApiException
-     * @throws \Google\ApiCore\ValidationException
+     * @throws ApiException
+     * @throws ValidationException
      */
     public function totalViews(Period $period): int
     {
@@ -24,8 +26,8 @@ trait ViewsAnalytics
     }
 
     /**
-     * @throws \Google\ApiCore\ApiException
-     * @throws \Google\ApiCore\ValidationException
+     * @throws ApiException
+     * @throws ValidationException
      */
     public function totalViewsByDate(Period $period): array
     {
@@ -40,8 +42,8 @@ trait ViewsAnalytics
     }
 
     /**
-     * @throws \Google\ApiCore\ApiException
-     * @throws \Google\ApiCore\ValidationException
+     * @throws ApiException
+     * @throws ValidationException
      */
     public function totalViewsByPage(Period $period): array
     {
@@ -54,8 +56,8 @@ trait ViewsAnalytics
     }
 
     /**
-     * @throws \Google\ApiCore\ApiException
-     * @throws \Google\ApiCore\ValidationException
+     * @throws ApiException
+     * @throws ValidationException
      */
     public function topViewsByPage(Period $period): array
     {
@@ -63,8 +65,8 @@ trait ViewsAnalytics
     }
 
     /**
-     * @throws \Google\ApiCore\ApiException
-     * @throws \Google\ApiCore\ValidationException
+     * @throws ApiException
+     * @throws ValidationException
      */
     public function leastViewsByPage(Period $period): array
     {
@@ -83,8 +85,8 @@ trait ViewsAnalytics
     }
 
     /**
-     * @throws \Google\ApiCore\ApiException
-     * @throws \Google\ApiCore\ValidationException
+     * @throws ApiException
+     * @throws ValidationException
      */
     public function totalViewsByPagePath(Period $period): array
     {
@@ -97,8 +99,8 @@ trait ViewsAnalytics
     }
 
     /**
-     * @throws \Google\ApiCore\ApiException
-     * @throws \Google\ApiCore\ValidationException
+     * @throws ApiException
+     * @throws ValidationException
      */
     public function topViewsByPagePath(Period $period, int $limit = 10): array
     {
@@ -113,8 +115,8 @@ trait ViewsAnalytics
     }
 
     /**
-     * @throws \Google\ApiCore\ApiException
-     * @throws \Google\ApiCore\ValidationException
+     * @throws ApiException
+     * @throws ValidationException
      */
     public function totalViewsByPageTitle(Period $period): array
     {
@@ -127,8 +129,8 @@ trait ViewsAnalytics
     }
 
     /**
-     * @throws \Google\ApiCore\ApiException
-     * @throws \Google\ApiCore\ValidationException
+     * @throws ApiException
+     * @throws ValidationException
      */
     public function topViewsByPageTitle(Period $period, int $limit = 10): array
     {
@@ -143,8 +145,8 @@ trait ViewsAnalytics
     }
 
     /**
-     * @throws \Google\ApiCore\ApiException
-     * @throws \Google\ApiCore\ValidationException
+     * @throws ApiException
+     * @throws ValidationException
      */
     public function totalViewsByPageUrl(Period $period): array
     {
@@ -157,8 +159,8 @@ trait ViewsAnalytics
     }
 
     /**
-     * @throws \Google\ApiCore\ApiException
-     * @throws \Google\ApiCore\ValidationException
+     * @throws ApiException
+     * @throws ValidationException
      */
     public function topViewsByPageUrl(Period $period, int $limit = 10): array
     {
@@ -173,8 +175,8 @@ trait ViewsAnalytics
     }
 
     /**
-     * @throws \Google\ApiCore\ApiException
-     * @throws \Google\ApiCore\ValidationException
+     * @throws ApiException
+     * @throws ValidationException
      */
     public function totalViewsByCountry(Period $period): array
     {
@@ -187,8 +189,8 @@ trait ViewsAnalytics
     }
 
     /**
-     * @throws \Google\ApiCore\ApiException
-     * @throws \Google\ApiCore\ValidationException
+     * @throws ApiException
+     * @throws ValidationException
      */
     public function topViewsByCountry(Period $period, int $limit = 10): array
     {
@@ -203,8 +205,8 @@ trait ViewsAnalytics
     }
 
     /**
-     * @throws \Google\ApiCore\ApiException
-     * @throws \Google\ApiCore\ValidationException
+     * @throws ApiException
+     * @throws ValidationException
      */
     public function totalViewsByCity(Period $period): array
     {
@@ -217,8 +219,8 @@ trait ViewsAnalytics
     }
 
     /**
-     * @throws \Google\ApiCore\ApiException
-     * @throws \Google\ApiCore\ValidationException
+     * @throws ApiException
+     * @throws ValidationException
      */
     public function topViewsByCity(Period $period, int $limit = 10): array
     {


### PR DESCRIPTION
This pull request does the following:

- Update `google/analytics-data` to 0.23.3 with correct types and replacement for deprecated classes
- Add `^13.0` to `illuminate/contracts` to support Laravel 13
- Update some dev dependencies to their latest versions